### PR TITLE
Fix handling of escaped backslashes, Refactor the parser

### DIFF
--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -1,7 +1,5 @@
 #include <ruby.h>
 
-VALUE PgArrayParser = Qnil;
-
 //Prototypes
 VALUE read_array(int *index, char *string, int length, char *word);
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string);
@@ -115,9 +113,6 @@ VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, c
 }
 
 void Init_pg_array_parser(void) {
-  PgArrayParser = rb_define_module("PgArrayParser");
-  rb_define_method(PgArrayParser, "parse_pg_array", parse_pg_array, 1);
-
+  rb_define_method(rb_define_module("PgArrayParser"), "parse_pg_array", parse_pg_array, 1);
 }
-
 

--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -24,67 +24,89 @@ VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, c
 {
   // Return value: array
   VALUE array;
-  array = rb_ary_new();
   int word_index = 0;
+
+  /* The current character in the input string. */
+  char c;
+
+  /*  0: Currently outside a quoted string, current word never quoted
+   *  1: Currently inside a quoted string
+   * -1: Currently outside a quoted string, current word previously quoted */
   int openQuote = 0;
+
+  /* Inside quoted input means the next character should be treated literally,
+   * instead of being treated as a metacharacter.
+   * Outside of quoted input, means that the word shouldn't be pushed to the array,
+   * used when the last entry was a subarray (which adds to the array itself). */
+  int escapeNext = 0;
+
+  array = rb_ary_new();
+
+  /* Special case the empty array, so it doesn't need to be handled manually inside
+   * the loop. */
+  if(((*index) < array_string_length) && c_pg_array_string[(*index)] == '}') 
+  {
+    return array;
+  }
+
   for(;(*index) < array_string_length; ++(*index))
   {
-    if(!openQuote && (c_pg_array_string[*index] == ','))
+    c = c_pg_array_string[*index];
+    if(openQuote < 1)
     {
-      if(c_pg_array_string[(*index) - 1] != '"' && c_pg_array_string[(*index) - 1] != '}')
+      if(c == ',' || c == '}')
       {
-        word[word_index] = '\0';
-        if (word_index == 4 && !strcmp(word,"NULL"))
+        if(!escapeNext)
         {
-          rb_ary_push(array, Qnil);
+          if(openQuote == 0 && word_index == 4 && !strncmp(word, "NULL", word_index))
+          {
+            rb_ary_push(array, Qnil);
+          }
+          else
+          {
+            rb_ary_push(array, rb_str_new(word, word_index));
+          }
         }
-        else
+        if(c == '}')
         {
-          rb_ary_push(array, rb_str_new2(word));
+          return array;
         }
+        escapeNext = 0;
+        openQuote = 0;
         word_index = 0;
       }
-    }
-    else if(!openQuote && c_pg_array_string[*index] == '}')
-    {
-      if(word_index > 0 && c_pg_array_string[(*index) - 1] != '"')
+      else if(c == '"')
       {
-        word[word_index] = '\0';
-        if (word_index == 4 && !strcmp(word,"NULL"))
-        {
-          rb_ary_push(array, Qnil);
-        }
-        else
-        {
-          rb_ary_push(array, rb_str_new2(word));
-        }
-        word_index = 0;
+        openQuote = 1;
       }
-      return array;
+      else if(c == '{')
+      {
+        (*index)++;
+        rb_ary_push(array, read_array(index, c_pg_array_string, array_string_length, word));
+        escapeNext = 1;
+      }
+      else
+      {
+        word[word_index] = c;
+        word_index++;
+      }
     }
-    else if (openQuote && c_pg_array_string[*index] == '"' && c_pg_array_string[(*index) - 1] == '\\')
-    {
-      word[word_index - 1] = '"';
+    else if (escapeNext) {
+      word[word_index] = c;
+      word_index++;
+      escapeNext = 0;
     }
-    else if (openQuote && c_pg_array_string[*index] == '"' && c_pg_array_string[(*index) - 1] != '\\')
+    else if (c == '\\')
     {
-      word[word_index] = '\0';
-      word_index = 0;
-      openQuote = 0;
-      rb_ary_push(array, rb_str_new2(word));
+      escapeNext = 1;
     }
-    else if(c_pg_array_string[*index] == '"')
+    else if (c == '"')
     {
-      openQuote = 1;
-    }
-    else if(!openQuote && c_pg_array_string[*index] == '{')
-    {
-      (*index)++;
-      rb_ary_push(array, read_array(index, c_pg_array_string, array_string_length, word));
+      openQuote = -1;
     }
     else
     {
-      word[word_index] = c_pg_array_string[*index];
+      word[word_index] = c;
       word_index++;
     }
   }

--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -3,7 +3,7 @@
 VALUE PgArrayParser = Qnil;
 
 //Prototypes
-VALUE read_array(int *index, char *string, int *length, char *word);
+VALUE read_array(int *index, char *string, int length, char *word);
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string);
 
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
@@ -15,19 +15,19 @@ VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
 
   int index = 1;
 
-  VALUE return_value = read_array(&index, c_pg_array_string, &array_string_length, word);
+  VALUE return_value = read_array(&index, c_pg_array_string, array_string_length, word);
   free(word);
   return return_value;
 }
 
-VALUE read_array(int *index, char *c_pg_array_string, int *array_string_length, char *word)
+VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, char *word)
 {
   // Return value: array
   VALUE array;
   array = rb_ary_new();
   int word_index = 0;
   int openQuote = 0;
-  for(;(*index) < (*array_string_length); ++(*index))
+  for(;(*index) < array_string_length; ++(*index))
   {
     if(!openQuote && (c_pg_array_string[*index] == ','))
     {

--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -1,11 +1,11 @@
 #include <ruby.h>
 
-//Prototype
+/* Prototype */
 VALUE read_array(int *index, char *string, int length, char *word);
 
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
 
-  //convert to c-string, create a buffer of the same length, as that will be the worst case
+  /* convert to c-string, create a buffer of the same length, as that will be the worst case */
   char *c_pg_array_string = StringValueCStr(pg_array_string);
   int array_string_length = RSTRING_LEN(pg_array_string);
   char *word = malloc(array_string_length + 1);
@@ -19,7 +19,7 @@ VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
 
 VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, char *word)
 {
-  // Return value: array
+  /* Return value: array */
   VALUE array;
   int word_index = 0;
 

--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -8,7 +8,7 @@ VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
   //convert to c-string, create a buffer of the same length, as that will be the worst case
   char *c_pg_array_string = StringValueCStr(pg_array_string);
   int array_string_length = RSTRING_LEN(pg_array_string);
-  char *word = malloc(sizeof(char) * (array_string_length + 1));
+  char *word = malloc(array_string_length + 1);
 
   int index = 1;
 

--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -1,8 +1,7 @@
 #include <ruby.h>
 
-//Prototypes
+//Prototype
 VALUE read_array(int *index, char *string, int length, char *word);
-VALUE parse_pg_array(VALUE self, VALUE pg_array_string);
 
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -9,59 +9,82 @@ describe 'PgArrayParser' do
 
   describe '#parse_pg_array' do
     context 'one dimensional arrays' do
+      context 'empty' do
+        it 'returns an empty array' do
+          parser.parse_pg_array(%[{}]).should == []
+        end
+      end
+
       context 'no strings' do
         it 'returns an array of strings' do
-          parser.parse_pg_array(%[{1,2,3}]).should eq ['1','2','3']
+          parser.parse_pg_array(%[{1,2,3}]).should == ['1','2','3']
         end
       end
 
       context 'NULL values' do
         it 'returns an array of strings, with nils replacing NULL characters' do
-          parser.parse_pg_array(%[{1,NULL,NULL}]).should eq ['1',nil,nil]
+          parser.parse_pg_array(%[{1,NULL,NULL}]).should == ['1',nil,nil]
         end
       end
 
       context 'quoted NULL' do
         it 'returns an array with the word NULL' do
-          parser.parse_pg_array(%[{1,"NULL",3}]).should eq ['1','NULL','3']
+          parser.parse_pg_array(%[{1,"NULL",3}]).should == ['1','NULL','3']
         end
       end
 
       context 'strings' do
         it 'returns an array of strings when containing commas in a quoted string' do
-          parser.parse_pg_array(%[{1,"2,3",4}]).should eq ['1','2,3','4']
+          parser.parse_pg_array(%[{1,"2,3",4}]).should == ['1','2,3','4']
         end
 
         it 'returns an array of strings when containing an escaped quote' do
-          parser.parse_pg_array(%[{1,"2\\",3",4}]).should eq ['1','2",3','4']
+          parser.parse_pg_array(%[{1,"2\\",3",4}]).should == ['1','2",3','4']
+        end
+
+        it 'returns an array of strings when containing an escaped backslash' do
+          parser.parse_pg_array(%[{1,"2\\\\",3,4}]).should == ['1','2\\','3','4']
+          parser.parse_pg_array(%[{1,"2\\\\\\",3",4}]).should == ['1','2\\",3','4']
         end
       end
     end
 
     context 'two dimensional arrays' do
+      context 'empty' do
+        it 'returns an empty array' do
+          parser.parse_pg_array(%[{{}}]).should == [[]]
+          parser.parse_pg_array(%[{{},{}}]).should == [[],[]]
+        end
+      end
       context 'no strings' do
         it 'returns an array of strings with a sub array' do
-          parser.parse_pg_array(%[{1,{2,3},4}]).should eq ['1',['2','3'],'4']
+          parser.parse_pg_array(%[{1,{2,3},4}]).should == ['1',['2','3'],'4']
         end
       end
       context 'strings' do
         it 'returns an array of strings with a sub array' do
-          parser.parse_pg_array(%[{1,{"2,3"},4}]).should eq ['1',['2,3'],'4']
+          parser.parse_pg_array(%[{1,{"2,3"},4}]).should == ['1',['2,3'],'4']
         end
         it 'returns an array of strings with a sub array and a quoted }' do
-          parser.parse_pg_array(%[{1,{"2,}3",NULL},4}]).should eq ['1',['2,}3',nil],'4']
+          parser.parse_pg_array(%[{1,{"2,}3",NULL},4}]).should == ['1',['2,}3',nil],'4']
         end
         it 'returns an array of strings with a sub array and a quoted {' do
-          parser.parse_pg_array(%[{1,{"2,{3"},4}]).should eq ['1',['2,{3'],'4']
+          parser.parse_pg_array(%[{1,{"2,{3"},4}]).should == ['1',['2,{3'],'4']
         end
         it 'returns an array of strings with a sub array and a quoted { and escaped quote' do
-          parser.parse_pg_array(%[{1,{"2\\",{3"},4}]).should eq ['1',['2",{3'],'4']
+          parser.parse_pg_array(%[{1,{"2\\",{3"},4}]).should == ['1',['2",{3'],'4']
         end
       end
     end
     context 'three dimensional arrays' do
+      context 'empty' do
+        it 'returns an empty array' do
+          parser.parse_pg_array(%[{{{}}}]).should == [[[]]]
+          parser.parse_pg_array(%[{{{},{}},{{},{}}}]).should == [[[],[]],[[],[]]]
+        end
+      end
       it 'returns an array of strings with sub arrays' do
-        parser.parse_pg_array(%[{1,{2,{3,4}},{NULL,6},7}]).should eq ['1',['2',['3','4']],[nil,'6'],'7']
+        parser.parse_pg_array(%[{1,{2,{3,4}},{NULL,6},7}]).should == ['1',['2',['3','4']],[nil,'6'],'7']
       end
     end
   end


### PR DESCRIPTION
The parser currently does not handle escaped backslashes in quoted input.  I have a commit that adds some specs for the desired behavior, then a series of commits that refactor the parser so that it not only handles escaped backslashes correctly, but should also be simpler and faster.  I used a series of commits as some of the changes I made are style issues that you may disagree with, so feel free to cherry-pick only the commits you want, or squash merge this into a single commit if you want everything.
