### PR TITLE
String encoding is preserved.

### DIFF
--- a/ext/pg_array_parser/pg_array_parser.c
+++ b/ext/pg_array_parser/pg_array_parser.c
@@ -1,7 +1,8 @@
 #include <ruby.h>
+#include <ruby/encoding.h>
 
 /* Prototype */
-VALUE read_array(int *index, char *string, int length, char *word);
+VALUE read_array(int *index, char *string, int length, char *word, rb_encoding *enc);
 
 VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
 
@@ -9,15 +10,16 @@ VALUE parse_pg_array(VALUE self, VALUE pg_array_string) {
   char *c_pg_array_string = StringValueCStr(pg_array_string);
   int array_string_length = RSTRING_LEN(pg_array_string);
   char *word = malloc(array_string_length + 1);
+  rb_encoding *enc = rb_enc_get(pg_array_string);
 
   int index = 1;
 
-  VALUE return_value = read_array(&index, c_pg_array_string, array_string_length, word);
+  VALUE return_value = read_array(&index, c_pg_array_string, array_string_length, word, enc);
   free(word);
   return return_value;
 }
 
-VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, char *word)
+VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, char *word, rb_encoding *enc)
 {
   /* Return value: array */
   VALUE array;
@@ -61,7 +63,7 @@ VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, c
           }
           else
           {
-            rb_ary_push(array, rb_str_new(word, word_index));
+            rb_ary_push(array, rb_enc_str_new(word, word_index, enc));
           }
         }
         if(c == '}')
@@ -79,7 +81,7 @@ VALUE read_array(int *index, char *c_pg_array_string, int array_string_length, c
       else if(c == '{')
       {
         (*index)++;
-        rb_ary_push(array, read_array(index, c_pg_array_string, array_string_length, word));
+        rb_ary_push(array, read_array(index, c_pg_array_string, array_string_length, word, enc));
         escapeNext = 1;
       }
       else

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'spec_helper'
 
 class Parser
@@ -51,6 +52,9 @@ describe 'PgArrayParser' do
           parser.parse_pg_array(%[{1,"",3,""}]).should eq ['1', '', '3', '']
         end
 
+        it 'returns an array containing unicode strings' do
+          parser.parse_pg_array(%[{"Paragraph 399(b)(i) – “valid leave” – meaning"}]).should eq(['Paragraph 399(b)(i) – “valid leave” – meaning'])
+        end
       end
     end
 


### PR DESCRIPTION
When you have a string that is not ASCII, you'll end up with garbage like: 

`["Paragraph 399(b)(i) \xE2\x80\x93 \xE2\x80\x9Cvalid leave\xE2\x80\x9D \xE2\x80\x93 meaning"]`

instead of:

`["Paragraph 399(b)(i) – “valid leave” – meaning"]`

This should work regardless of what encoding the string is in.
