### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pull requests to specific branches rather than master.
 
 Please make sure you include tests!
 
-Unles Rails drops support for Ruby 1.8.7 we will continue to use the
+Unless Rails drops support for Ruby 1.8.7 we will continue to use the
 hash-rocket syntax. Please respect this.
 
 Don't use tabs to indent, two spaces are the standard.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ pull requests to specific branches rather than master.
 
 Please make sure you include tests!
 
-Unless Rails drops support for Ruby 1.8.7 we will continue to use the
-hash-rocket syntax. Please respect this.
-
 Don't use tabs to indent, two spaces are the standard.
 
 ## Legal ##


### PR DESCRIPTION
s/Unles/Unless

btw, as Rails 4.0 dropped 1.8.7 support, it seems reasonable to use 1.9 hash syntax now.
