### PR TITLE
Fix Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PgArrayParser
-[![Build Status](http://travis-ci.org/dockyard/easy_auth.png)](http://travis-ci.org/dockyard/pg_array_parser)
+[![Build Status](http://travis-ci.org/DockYard/pg_array_parser.png)](http://travis-ci.org/DockYard/pg_array_parser)
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/dockyard/pg_array_parser)
 
 Fast PostreSQL array parsing.


### PR DESCRIPTION
Travis seems to care about case, and the project name was incorrect.

The [rich diff](https://github.com/DockYard/pg_array_parser/pull/12/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8):

<img width="321" alt="screenshot 2016-03-06 11 07 12" src="https://cloud.githubusercontent.com/assets/14028/13551370/9f2195b2-e38b-11e5-8889-b4ec48813f3a.png">
