### PR TITLE
Add license to gemspec.

### DIFF
--- a/pg_array_parser.gemspec
+++ b/pg_array_parser.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Simple library to parse PostgreSQL arrays into a array of strings}
   gem.summary       = %q{Converts PostgreSQL array strings into arrays of strings}
   gem.homepage      = "https://github.com/dockyard/pg_array_parser"
+  gem.license       = "MIT"
 
   gem.files         = [ 'CHANGELOG.md',
                         'Gemfile',


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com/ruby/pg_array_parser/) and for us the license information is very important. It would be extremely helpful if this information would be available in the gemspec. Many thanks. Robert.
